### PR TITLE
Gracefully handle so-server fetch failures

### DIFF
--- a/js/packages/teams-ai/src/mcp/so-server.ts
+++ b/js/packages/teams-ai/src/mcp/so-server.ts
@@ -10,9 +10,20 @@ const resource: ResourceDefinition = {
     async read() {
         const url =
             'https://api.stackexchange.com/2.3/questions?tagged=microsoft-teams&pagesize=20&order=desc&sort=creation&site=stackoverflow&filter=withbody';
-        const response = await fetch(url);
-        const json = await response.json();
-        return JSON.stringify(json.items);
+        try {
+            const response = await fetch(url);
+            if (!response.ok) {
+                console.error(
+                    `Failed to fetch questions: ${response.status} ${response.statusText}`
+                );
+                return JSON.stringify([]);
+            }
+            const json = await response.json();
+            return JSON.stringify(json.items);
+        } catch (err) {
+            console.error('Error fetching questions:', err);
+            return JSON.stringify([]);
+        }
     }
 };
 


### PR DESCRIPTION
## Summary
- log errors when fetching StackOverflow questions fails
- return an empty list if fetch fails

## Testing
- `npm test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842985b12d0832380cf5c738563745e