### PR TITLE
Fix MCP typings

### DIFF
--- a/js/packages/teams-ai/src/@types/@microsoft/teams.mcp/index.d.ts
+++ b/js/packages/teams-ai/src/@types/@microsoft/teams.mcp/index.d.ts
@@ -1,6 +1,8 @@
-export interface ResourceDefinition {
-    uri: string;
-    name: string;
-    mimeType: string;
-    read(): Promise<string>;
+declare module '@microsoft/teams.mcp' {
+    export interface ResourceDefinition {
+        uri: string;
+        name: string;
+        mimeType: string;
+        read(): Promise<string>;
+    }
 }

--- a/js/packages/teams-ai/src/@types/@microsoft/teams.mcp/server.d.ts
+++ b/js/packages/teams-ai/src/@types/@microsoft/teams.mcp/server.d.ts
@@ -1,14 +1,16 @@
-export interface ServerOptions {
-    port: number;
-}
-export interface ResourceDefinition {
-    uri: string;
-    name: string;
-    mimeType: string;
-    read(): Promise<string>;
-}
-export class McpServer {
-    constructor(options: ServerOptions);
-    add(resource: ResourceDefinition): void;
-    listen(callback: () => void): void;
+declare module '@microsoft/teams.mcp/server' {
+    export interface ServerOptions {
+        port: number;
+    }
+    export interface ResourceDefinition {
+        uri: string;
+        name: string;
+        mimeType: string;
+        read(): Promise<string>;
+    }
+    export class McpServer {
+        constructor(options: ServerOptions);
+        add(resource: ResourceDefinition): void;
+        listen(callback: () => void): void;
+    }
 }


### PR DESCRIPTION
## Summary
- augment mcp module definitions with proper `declare module` syntax

## Testing
- `npx tsc --noEmit --pretty false src/mcp/so-server.ts` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6842b7197694832388706ab736305137